### PR TITLE
install-legacy: fix systemd unit and daemon-reload

### DIFF
--- a/install-legacy.sh
+++ b/install-legacy.sh
@@ -62,7 +62,7 @@ EOF
 echo ""
 echo ""
 # you have to daemon-reload for systemd to recognize the new unit
-echo "First, reload systemd: 'systemctl daemon-reload"', then"
+echo "First, reload systemd: 'systemctl daemon-reload', then"
 echo "Start service: 'systemctl start $service'"
 echo ""
 echo "################"

--- a/install-legacy.sh
+++ b/install-legacy.sh
@@ -44,14 +44,13 @@ cat <<EOF
 [Unit]
 Description=UTDON - Application for tracking obsolete FOSS applications
 After=networking.service
-[environment]
-USER_ENCRYPT_SECRET=$USER_ENCRYPT_SECRET
-DATABASE_ENCRYPT_SECRET=$DATABASE_ENCRYPT_SECRET
 [Service]
 WorkingDirectory=$installdir
 ExecStart=node main.js
 User=$service
 Group=$service
+Environment="USER_ENCRYPT_SECRET=$USER_ENCRYPT_SECRET"
+Environment="DATABASE_ENCRYPT_SECRET=$DATABASE_ENCRYPT_SECRET"
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=$service

--- a/install-legacy.sh
+++ b/install-legacy.sh
@@ -59,8 +59,11 @@ Restart=always
 [Install]
 WantedBy=multi-user.target
 EOF
+
 echo ""
 echo ""
+# you have to daemon-reload for systemd to recognize the new unit
+echo "First, reload systemd: 'systemctl daemon-reload"', then"
 echo "Start service: 'systemctl start $service'"
 echo ""
 echo "################"


### PR DESCRIPTION
1.  Systemd needs daemon-reload to take the new unit into consideration
Otherwise if you try to start it, systemd will not find the unit (`Failed to start utdon.service: Unit utdon.service not found.`).

2. A systemd service doesn't have a `[Environment]` section. Env variables are passed throught Environment= or EnvironmentFile=, according to the [doc](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#id-1.9.8)

Et merci beaucoup pour le reste du logiciel ! 